### PR TITLE
Sush/fetch pkmn description img

### DIFF
--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -291,8 +291,8 @@ function fetchPokeFlavourText(species) {
             console.log("species data");
             console.log(speciesData);
 
-            // var flavourTexts = speciesData.flavor_text_entries;
-            // var allFlavourTexts = [];
+            var flavourTexts = speciesData.flavor_text_entries;
+            var allFlavourTexts = [];
 
             
 

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -195,7 +195,6 @@ var typeInfo = {
 
 // CONNECT TO pokéAPI
 
-
 function getPokeApi() {
     // add query 'limit=1126' to retrieve every pokémon (else it will retrieve 20 results at a time)
     var pokemonApiUrl = "https://pokeapi.co/api/v2/pokemon/?limit=1126";
@@ -234,6 +233,7 @@ function getPokeApi() {
                 pokemon[772], // random choice: silvally
             ];
 
+            // for each of the above items, grab the pokemon url and pass it on
             selectedPokemon.forEach(function (pokemon) {
                 getPokemonInfo(pokemon.url);
             });
@@ -255,26 +255,27 @@ function getPokemonInfo(url) {
         })
         .then(function (data) {
             // console.log(data);
+            // get pokemon name
+            let name = data.name;
+            // get pokemon id number
+            let id = data.id;
 
-            var name = data.name;
-            getPokemonName(typeInfo, name);
+            // get pokemon artwork url by first retrieving data from pokeAPI
+            let artLocation = data.sprites.other["official-artwork"].front_default;
+            // make the url a string
+            let artwork = `${artLocation}`;
 
-            var id = data.id;
-            getPokemonId(typeInfo, name, id);
+            // get species data urls
+            let species = data.species.url;
 
-            // var type = data.types[0].type.name;
-            // getPokemonType(typeInfo, name, type);
+            // pass specified variables on to populate 'typeInfo' object
+            fillPokemonDetails(typeInfo, name, id, artwork);
+            getPokemonSpecies(typeInfo, species);
 
-            var artwork = "";
-            var artLocation = data.sprites.other["official-artwork"].front_default;
-            artwork += artLocation;
-            getPokemonArt(typeInfo, name, artwork);
-
-            var species = data.species.url;
-            getPokemonSpecies(typeInfo, name, species);
-
-            console.log("get pokemon info: ");
             console.log(typeInfo);
+            
+            // POKEMON LOGIC FUNCTION SHOULD PROBABLY BE ADDED HERE and typeInfo object passed to it
+            // eg. determinePokeArtistMatch(typeInfo);
 
         })
         .catch(function (error) {
@@ -282,367 +283,8 @@ function getPokemonInfo(url) {
         });
 }
 
-function getPokemonName(typeobj, name) {
-    let pokemon = name;
-
-    switch (pokemon) {
-        case "kricketune":
-            typeobj.bug.name = name;
-            // console.log(typeobj);
-            break;
-        case "zoroark":
-            typeobj.dark.name = name;
-            // console.log(typeobj);
-            break;
-        case "latios":
-            typeobj.dragon.name = name;
-            // console.log(typeobj);
-            break;
-        case "mareep":
-            typeobj.electric.name = name;
-            // console.log(typeobj);
-            break;
-        case "sylveon":
-            typeobj.fairy.name = name;
-            // console.log(typeobj);
-            break;
-
-        case "urshifu-single-strike":
-            let urshifu = name.split("-")[0];
-            typeobj.fighting.name = urshifu;
-            // console.log(typeobj);
-            break;
-        case "torracat":
-            typeobj.fire.name = name;
-            // console.log(typeobj);
-            break;
-        case "pidgeotto":
-            typeobj.flying.name = name;
-            // console.log(typeobj);
-            break;
-        case "banette":
-            typeobj.ghost.name = name;
-            // console.log(typeobj);
-            break;
-        case "roserade":
-            typeobj.grass.name = name;
-            // console.log(typeobj);
-            break;
-
-        case "piloswine":
-            typeobj.ground.name = name;
-            // console.log(typeobj);
-            break;
-        case "bergmite":
-            typeobj.ice.name = name;
-            // console.log(typeobj);
-            break;
-        case "lickitung":
-            typeobj.normal.name = name;
-            // console.log(typeobj);
-            break;
-        case "skuntank":
-            typeobj.poison.name = name;
-            // console.log(typeobj);
-            break;
-        case "hatterene":
-            typeobj.psychic.name = name;
-            // console.log(typeobj);
-            break;
-
-        case "gigalith":
-            typeobj.rock.name = name;
-            // console.log(typeobj);
-            break;
-        case "aggron":
-            typeobj.steel.name = name;
-            // console.log(typeobj);
-            break;
-        case "primarina":
-            typeobj.water.name = name;
-            // console.log(typeobj);
-            break;
-        case "silvally":
-            typeobj.random.name = name;
-            // console.log(typeobj);
-            break;
-        default: 
-            console.log("default break: nothing");
-            break;
-    }
-}
-
-function getPokemonId(typeobj, name, id) {
-    let pokemon = name;
-
-    switch (pokemon) {
-        case "kricketune":
-            typeobj.bug.id = id;
-            // console.log(typeobj);
-            break;
-        case "zoroark":
-            typeobj.dark.id = id;
-            // console.log(typeobj);
-            break;
-        case "latios":
-            typeobj.dragon.id = id;
-            // console.log(typeobj);
-            break;
-        case "mareep":
-            typeobj.electric.id = id;
-            // console.log(typeobj);
-            break;
-        case "sylveon":
-            typeobj.fairy.id = id;
-            // console.log(typeobj);
-            break;
-
-        case "urshifu-single-strike":
-            typeobj.fighting.id = id;
-            // console.log(typeobj);
-            break;
-        case "torracat":
-            typeobj.fire.id = id;
-            // console.log(typeobj);
-            break;
-        case "pidgeotto":
-            typeobj.flying.id = id;
-            // console.log(typeobj);
-            break;
-        case "banette":
-            typeobj.ghost.id = id;
-            // console.log(typeobj);
-            break;
-        case "roserade":
-            typeobj.grass.id = id;
-            // console.log(typeobj);
-            break;
-
-        case "piloswine":
-            typeobj.ground.id = id;
-            // console.log(typeobj);
-            break;
-        case "bergmite":
-            typeobj.ice.id = id;
-            // console.log(typeobj);
-            break;
-        case "lickitung":
-            typeobj.normal.id = id;
-            // console.log(typeobj);
-            break;
-        case "skuntank":
-            typeobj.poison.id = id;
-            // console.log(typeobj);
-            break;
-        case "hatterene":
-            typeobj.psychic.id = id;
-            // console.log(typeobj);
-            break;
-
-        case "gigalith":
-            typeobj.rock.id = id;
-            // console.log(typeobj);
-            break;
-        case "aggron":
-            typeobj.steel.id = id;
-            // console.log(typeobj);
-            break;
-        case "primarina":
-            typeobj.water.id = id;
-            // console.log(typeobj);
-            break;
-        case "silvally": 
-            typeobj.random.id = id;
-            // console.log(typeobj);
-            break;
-        default:
-            console.log("default break: nothing");
-            break;
-    }
-}
-
-// function getPokemonType here (don't actually need it)
-/*
-function getPokemonType(typeobj, name, type) {
-    let pokemon = name;
-
-    switch (pokemon) {
-        case "kricketune":
-            typeobj.bug.type = type;
-            console.log(typeobj);
-            break;
-        case "zoroark":
-            typeobj.dark.type = type;
-            console.log(typeobj);
-            break;
-        case "latios":
-            typeobj.dragon.type = type;
-            console.log(typeobj);
-            break;
-        case "mareep":
-            typeobj.electric.type = type;
-            console.log(typeobj);
-            break;
-        case "sylveon":
-            typeobj.fairy.type = type;
-            console.log(typeobj);
-            break;
-
-        case "urshifu-single-strike":
-            typeobj.fighting.type = type;
-            console.log(typeobj);
-            break;
-        case "torracat":
-            typeobj.fire.type = type;
-            console.log(typeobj);
-            break;
-        case "ptypegeotto":
-            typeobj.flying.type = type;
-            console.log(typeobj);
-            break;
-        case "banette":
-            typeobj.ghost.type = type;
-            console.log(typeobj);
-            break;
-        case "roserade":
-            typeobj.grass.type = type;
-            console.log(typeobj);
-            break;
-
-        case "piloswine":
-            typeobj.ground.type = type;
-            console.log(typeobj);
-            break;
-        case "bergmite":
-            typeobj.ice.type = type;
-            console.log(typeobj);
-            break;
-        case "lickitung":
-            typeobj.normal.type = type;
-            console.log(typeobj);
-            break;
-        case "skuntank":
-            typeobj.poison.type = type;
-            console.log(typeobj);
-            break;
-        case "hatterene":
-            typeobj.psychic.type = type;
-            console.log(typeobj);
-            break;
-
-        case "gigalith":
-            typeobj.rock.type = type;
-            console.log(typeobj);
-            break;
-        case "aggron":
-            typeobj.steel.type = type;
-            console.log(typeobj);
-            break;
-        case "primarina":
-            typeobj.water.type = type;
-            console.log(typeobj);
-            break;
-        case "silvally": 
-            typeobj.random.type = type;
-            console.log(typeobj);
-            break;
-        default:
-            console.log("default break: nothing");
-            break;
-    }
-}
-*/
-
-function getPokemonArt(typeobj, name, artwork) {
-    let pokemon = name;
-
-    switch (pokemon) {
-        case "kricketune":
-            typeobj.bug.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "zoroark":
-            typeobj.dark.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "latios":
-            typeobj.dragon.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "mareep":
-            typeobj.electric.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "sylveon":
-            typeobj.fairy.artwork = artwork;
-            // console.log(typeobj);
-            break;
-
-        case "urshifu-single-strike":
-            typeobj.fighting.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "torracat":
-            typeobj.fire.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "partworkgeotto":
-            typeobj.flying.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "banette":
-            typeobj.ghost.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "roserade":
-            typeobj.grass.artwork = artwork;
-            // console.log(typeobj);
-            break;
-
-        case "piloswine":
-            typeobj.ground.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "bergmite":
-            typeobj.ice.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "lickitung":
-            typeobj.normal.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "skuntank":
-            typeobj.poison.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "hatterene":
-            typeobj.psychic.artwork = artwork;
-            // console.log(typeobj);
-            break;
-
-        case "gigalith":
-            typeobj.rock.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "aggron":
-            typeobj.steel.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "primarina":
-            typeobj.water.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        case "silvally": 
-            typeobj.random.artwork = artwork;
-            // console.log(typeobj);
-            break;
-        default:
-            console.log("default break: nothing");
-            break;
-    }
-}
-
-function getPokemonSpecies(typeobj, name, species) {
+// get the species url 
+function getPokemonSpecies(typeobj, species) {
     // console.log(url);
     fetch(species)
         .then(function (response) {
@@ -653,301 +295,228 @@ function getPokemonSpecies(typeobj, name, species) {
             }
         })
         .then(function (speciesdata) {
-            // console.log(speciesdata);
-            getEntry(typeobj, name, speciesdata);
+            // pass the results on to next function, to choose specific dex entry
+            getEntry(typeobj, speciesdata);
         })
         .catch(function (error) {
             console.log(error);
         });
 }
 
-function getEntry(typeobj, name, speciesdata) {
+// retrieve specific Pokédex entry for each pokemon
+function getEntry(typeobj, speciesdata) {
+    // console.log(speciesdata);
+    let pokemon = speciesdata.name;
     let entry = speciesdata.flavor_text_entries;
-    let pokemon = name;
 
+    // depending on the name of the pokemon,
     switch (pokemon) {
+        // in this case 'kricketune'
         case "kricketune":
+            // add to 'typeInfo' object under 'bug' key: flavour text entry #4
             typeobj.bug.entry = entry[3].flavor_text;
-            // console.log(typeobj);
             break;
+        // in this case 'zoroark'
         case "zoroark":
+            // add to 'typeInfo' object under 'dark' key: flavour text entry #4
             typeobj.dark.entry = entry[3].flavor_text;
-            // console.log(typeobj);
             break;
+        // and so on
         case "latios":
             typeobj.dragon.entry = entry[2].flavor_text;
-            // console.log(typeobj);
             break;
         case "mareep":
             typeobj.electric.entry = entry[5].flavor_text;
-            // console.log(typeobj);
             break;
         case "sylveon":
             typeobj.fairy.entry = entry[6].flavor_text;
-            // console.log(typeobj);
             break;
 
-        case "urshifu-single-strike":
+        case "urshifu":
             typeobj.fighting.entry = entry[7].flavor_text;
-            // console.log(typeobj);
             break;
         case "torracat":
             typeobj.fire.entry = entry[58].flavor_text;
-            // console.log(typeobj);
             break;
-        case "pentrygeotto":
+        case "pidgeotto":
             typeobj.flying.entry = entry[14].flavor_text;
-            // console.log(typeobj);
             break;
         case "banette":
             typeobj.ghost.entry = entry[3].flavor_text;
-            // console.log(typeobj);
             break;
         case "roserade":
             typeobj.grass.entry = entry[1].flavor_text;
-            // console.log(typeobj);
             break;
 
         case "piloswine":
             typeobj.ground.entry = entry[6].flavor_text;
-            // console.log(typeobj);
             break;
         case "bergmite":
             typeobj.ice.entry = entry[39].flavor_text;
-            // console.log(typeobj);
             break;
         case "lickitung":
             typeobj.normal.entry = entry[9].flavor_text;
-            // console.log(typeobj);
             break;
         case "skuntank":
             typeobj.poison.entry = entry[0].flavor_text;
-            // console.log(typeobj);
             break;
         case "hatterene":
             typeobj.psychic.entry = entry[7].flavor_text;
-            // console.log(typeobj);
             break;
 
         case "gigalith":
             typeobj.rock.entry = entry[1].flavor_text;
-            // console.log(typeobj);
             break;
         case "aggron":
             typeobj.steel.entry = entry[2].flavor_text;
-            // console.log(typeobj);
             break;
         case "primarina":
             typeobj.water.entry = entry[37].flavor_text;
-            // console.log(typeobj);
             break;
-        case "silvally": 
-            typeobj.random.entry = entry[7].flavor_text;
-            // console.log(typeobj);
-            break;
+        /* silvally as a case is commented out for now (the default case should be silvally) */
+        // case "silvally": 
+        //     typeobj.random.entry = entry[7].flavor_text;
+        //     break;
         default:
-            console.log("default break: nothing");
+            // the default case will use the pokemon Silvally
+            pokemon = "silvally";
+            // set value of 'random' key in object 'typeInfo' with flavour text entry #8
+            typeobj.random.entry = entry[7].flavor_text;
+            // console.log("default break at get-entry function");
+            break;
+    }
+}
+
+// this will fill 'typeInfo' object with three keys: poké name, poké ID no., poké artwork url
+function fillPokemonDetails(typeobj, name, id, artwork) {
+    let pokemon = name;
+    // console.log(pokemon);
+
+    // using the pokemon name as a determiner
+    switch (pokemon) {
+        // for the case of 'kricketune'
+        case "kricketune":
+            // add to typeInfo object under 'bug' key: name, id, artwork url values of kricketune
+            typeobj.bug.name = name;
+            typeobj.bug.id = id;
+            typeobj.bug.artwork = artwork;
+            break;
+        // for the case of 'zoroark'
+        case "zoroark":
+            // add to typeInfo object under 'dark' key: name, id, artwork url values of zoroark
+            typeobj.dark.name = name;
+            typeobj.dark.id = id;
+            typeobj.dark.artwork = artwork;
+            break;
+        // and so on
+        case "latios":
+            typeobj.dragon.name = name;
+            typeobj.dragon.id = id;
+            typeobj.dragon.artwork = artwork;
+            break;
+        case "mareep":
+            typeobj.electric.name = name;
+            typeobj.electric.id = id;
+            typeobj.electric.artwork = artwork;
+            break;
+        case "sylveon":
+            typeobj.fairy.name = name;
+            typeobj.fairy.id = id;
+            typeobj.fairy.artwork = artwork;
+            break;
+
+        // for urshifu's name, need to do some clipping
+        case "urshifu-single-strike":
+            // first split the name 'urshifu-single-strike' at the "-"
+            let urshifu = name.split("-")[0];
+            // add to 'fighting' key only the first part of the name (aka 'urshifu')
+            typeobj.fighting.name = urshifu;
+            typeobj.fighting.id = id;
+            typeobj.fighting.artwork = artwork;
+            break;
+        case "torracat":
+            typeobj.fire.name = name;
+            typeobj.fire.id = id;
+            typeobj.fire.artwork = artwork;
+            break;
+        case "pidgeotto":
+            typeobj.flying.name = name;
+            typeobj.flying.id = id;
+            typeobj.flying.artwork = artwork;
+            break;
+        case "banette":
+            typeobj.ghost.name = name;
+            typeobj.ghost.id = id;
+            typeobj.ghost.artwork = artwork;
+            break;
+        case "roserade":
+            typeobj.grass.name = name;
+            typeobj.grass.id = id;
+            typeobj.grass.artwork = artwork;
+            break;
+
+        case "piloswine":
+            typeobj.ground.name = name;
+            typeobj.ground.id = id;
+            typeobj.ground.artwork = artwork;
+            break;
+        case "bergmite":
+            typeobj.ice.name = name;
+            typeobj.ice.id = id;
+            typeobj.ice.artwork = artwork;
+            break;
+        case "lickitung":
+            typeobj.normal.name = name;
+            typeobj.normal.id = id;
+            typeobj.normal.artwork = artwork;
+            break;
+        case "skuntank":
+            typeobj.poison.name = name;
+            typeobj.poison.id = id;
+            typeobj.poison.artwork = artwork;
+            break;
+        case "hatterene":
+            typeobj.psychic.name = name;
+            typeobj.psychic.id = id;
+            typeobj.psychic.artwork = artwork;
+            break;
+
+        case "gigalith":
+            typeobj.rock.name = name;
+            typeobj.rock.id = id;
+            typeobj.rock.artwork = artwork;
+            break;
+        case "aggron":
+            typeobj.steel.name = name;
+            typeobj.steel.id = id;
+            typeobj.steel.artwork = artwork;
+            break;
+        case "primarina":
+            typeobj.water.name = name;
+            typeobj.water.id = id;
+            typeobj.water.artwork = artwork;
+            break;
+        /* silvally as a case is commented out for now (the default case should be silvally) */
+        // case "silvally": 
+        //     typeobj.random.name = name;
+        //     typeobj.random.id = id;
+        //     typeobj.random.artwork = artwork;
+        //     // console.log(typeobj);
+        //     break;
+        default:
+            // set the default pokemon name to "silvally"
+            pokemon = "silvally";
+            // add silvally's name, ID, artwork url values to the 'random' key in typeInfo object
+            typeobj.random.name = name;
+            typeobj.random.id = id;
+            typeobj.random.artwork = artwork;
+            // console.log("default break at fill-details function");
             break;
     }
 }
 
 getPokeApi();
 
-
-/* 
-// first call to pokéAPI: fetch data for all pokémon
-function getPokeApi() {
-    // add query 'limit=1126' to retrieve every pokémon (else it will retrieve 20 results at a time)
-    var pokemonApiUrl = "https://pokeapi.co/api/v2/pokemon/?limit=1126";
-
-    fetch(pokemonApiUrl)
-        .then(function (response) {
-            if (!response.ok) {
-                throw response.json();
-            } else {
-                return response.json();
-            }
-        })
-        .then(function (allPokemonData) {
-            let pokemon = allPokemonData.results;
-
-            // initial array to hold specific pokemon
-            let selectedPokemon = [
-                pokemon[401], // bug type: kricketune
-                pokemon[570], // dark type: zoroark
-                pokemon[380], // dragon type: latios
-                pokemon[178], // electric type: mareep
-                pokemon[699], // fairy type: sylveon
-                pokemon[891], // fighting type: urshifu
-                pokemon[725], // fire type: torracat
-                pokemon[16], // flying type: pidgeotto
-                pokemon[353], // ghost type: banette
-                pokemon[406], // grass type: roserade
-                pokemon[220], // ground type: piloswine
-                pokemon[711], // ice type: bergmite
-                pokemon[107], // normal type: lickitung
-                pokemon[434], // poison type: skuntank
-                pokemon[857], // psychic type: hatterene
-                pokemon[525], // rock type: gigalith
-                pokemon[305], // steel type: aggron
-                pokemon[729], // water type: primarina
-                pokemon[772], // random choice: silvally
-            ];
-
-            // loop thru each pokemon in array to get required info
-            selectedPokemon.forEach(function (pokemon) {
-                // pass on info to get the pokemon name
-                getPokeName(pokemon.name);
-                // pass on url data to function for grabbing type
-                getPokeType(pokemon.url);
-                // pass on url to function for grabbing species data
-                fetchPokeSpecies(pokemon.url);
-            });
-        })
-        .catch(function (error) {
-            console.log(error);
-        });
-}
-
-// get the name of the pokemon
-function getPokeName(name) {
-    // grab the pokemon name and push it to pokeName array
-    pokeName.push(name);
-
-    // making it so Urshifu's name is only "Urshifu" and not "Urshifu-single-strike"
-    if (name.includes("urshifu")) {
-        // grab name that includes "urshifu", split it by "-" and target index 0 ("urshifu")
-        var urshifu = name.split("-")[0];
-        // delete "urshifu-single-strike" from the name array
-        pokeName.pop();
-        // add just "urshifu" back into the name array
-        pokeName.push(urshifu);
-    }
-}
-
-// get the pokemon's type through second fetch call
-function getPokeType(pokemonUrl) {
-    // fetch data using pokemon.url
-    fetch(pokemonUrl)
-        .then(function (response) {
-            if (!response.ok) {
-                throw response.json();
-            } else {
-                return response.json();
-            }
-        })
-        .then(function(urlData) {
-            // for readability, make a variable 'type' and assign it the fetched data
-            var type = urlData.types[0].type.name;
-            // push the type to the pokeType array
-            pokeType.push(type);
-        })
-        .catch(function (error) {
-            console.log(error);
-        });
-}
-
-// get pokemon species data which will include official artwork url and another link to retrieve flavour text
-function fetchPokeSpecies(pokemonUrl) {
-    // fetch data using pokemon.url
-    fetch(pokemonUrl)
-        .then(function (response) {
-            if (!response.ok) {
-                throw response.json();
-            } else {
-                return response.json();
-            }
-        })
-        .then(function (urlData) {
-            // set an empty string
-            var artUrl = "";
-            // grab url for official artwork
-            var officialArt = urlData.sprites.other["official-artwork"].front_default;
-            // add the retrieved url to the empty string
-            artUrl += officialArt;
-
-            // pass art url on
-            getPokeArt(artUrl);
-
-            // grab each species' data url
-            var species = urlData.species.url;
-            // pass it on to get flavour text
-            fetchPokeFlavourText(species);
-        })
-        .catch(function (error) {
-            console.log(error);
-        });
-}
-
-// to get the official artwork img url
-function getPokeArt(arturl) {
-    // get the artwork url and push it to pokeArtwork array
-    pokeArtwork.push(arturl);
-    console.log(arturl);
-}
-
-// to get the pokemon's pokedex entry (species flavour text)
-function fetchPokeFlavourText(species) {
-    fetch(species)
-        .then(function (response) {
-            if (!response.ok) {
-                throw response.json();
-            } else {
-                return response.json();
-            }
-        })
-        .then(function (speciesData) {
-            // pass on all species data to next function
-            assignPokeEntry(speciesData);
-        })
-        .catch(function (error) {
-            console.log(error);
-        });
-
-}
-
-// IMPORTANT NOTE: because there are a lot of different flavour text entries available for each pokemon (and a number of them are in languages other than English), and because not all entries assigned to the first index of flavour_text_entries are in English, it's important to be able to select the specific flavour text we want
-
-// pick the specific flavour text to use for each pokemon
-function assignPokeEntry(speciesdata) {
-    // target the name of pokemon to enable switch case usage
-    let name = speciesdata.name;
-    // let unorderedPokeEntry = [];
-    // let index = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
-
-    
-    //     if (name.includes("kricketune")) {
-    //         unorderedPokeEntry[1].push("kricketune " + speciesdata.flavor_text_entries[3].flavor_text);
-    //     }
-
-    //     if (name.includes("zoroark")) {
-    //         unorderedPokeEntry[2].push(speciesdata.flavor_text_entries[3].flavor_text);
-    //     }
-
-    //     if (name.includes("latios")) {
-    //         unorderedPokeEntry[3].push(speciesdata.flavor_text_entries[2].flavor_text);
-    //     }
-
-    //     if (name.includes("mareep")) {
-    //         unorderedPokeEntry[4].push(speciesdata.flavor_text_entries[5].flavor_text);
-    //     }
-
-    //     if (name.includes("sylveon")) {
-    //         unorderedPokeEntry[5].push(speciesdata.flavor_text_entries[6].flavor_text);
-    //     }
-
-    //     if (name.includes("urshifu")) {
-    //         unorderedPokeEntry[6].push(speciesdata.flavor_text_entries[7].flavor_text);
-    //     }
-
-    //     console.log(unorderedPokeEntry);
-    //     return unorderedPokeEntry;
-    // }
-}
-
-getPokeApi();
-
-*/
 
 //THIS EVENT LISTENER WILL NEED TO CHANGE TO THE FORM SUBMIT BUTTON WHEN WE CREATE THE USER INPUT FIELD
 artistBtn.addEventListener("click", getSpotifyToken)

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -150,7 +150,7 @@ function getPokeApi() {
                 // pass on url data to function for grabbing type
                 getPokeType(pokemon.url);
                 // pass on url to function for grabbing species data
-                getPokeSpecies(pokemon.url);
+                fetchPokeSpecies(pokemon.url);
             });
         })
         .catch(function (error) {
@@ -162,6 +162,16 @@ function getPokeApi() {
 function getPokeName(name) {
     // grab the pokemon name and push it to pokeName array
     pokeName.push(name);
+
+    // making it so Urshifu's name is only "Urshifu" and not "Urshifu-single-strike"
+    if (name.includes("urshifu")) {
+        // grab name that includes "urshifu", split it by "-" and target index 0 ("urshifu")
+        var urshifu = name.split("-")[0];
+        // delete "urshifu-single-strike" from the name array
+        pokeName.pop();
+        // add just "urshifu" back into the name array
+        pokeName.push(urshifu);
+    }
 }
 
 // get the pokemon's type through second fetch call
@@ -175,10 +185,9 @@ function getPokeType(pokemonUrl) {
                 return response.json();
             }
         })
-        .then(function(pokeData) {
+        .then(function(urlData) {
             // for readability, make a variable 'type' and assign it the fetched data
-            var type = pokeData.types[0].type.name;
-
+            var type = urlData.types[0].type.name;
             // push the type to the pokeType array
             pokeType.push(type);
         })
@@ -187,7 +196,8 @@ function getPokeType(pokemonUrl) {
         });
 }
 
-function getPokeSpecies(pokemonUrl) {
+// get pokemon species data which will include official artwork url and another link to retrieve flavour text
+function fetchPokeSpecies(pokemonUrl) {
     // fetch data using pokemon.url
     fetch(pokemonUrl)
         .then(function (response) {
@@ -197,18 +207,21 @@ function getPokeSpecies(pokemonUrl) {
                 return response.json();
             }
         })
-        .then(function (pokeData) {
+        .then(function (urlData) {
+            // set an empty string
+            var artUrl = "";
             // grab url for official artwork
-            var officialArt = pokeData.sprites.other["official-artwork"].front_default;
-            // turn it into a string using template literals (template strings)
-            var artUrl = `"${officialArt}"`;
+            var officialArt = urlData.sprites.other["official-artwork"].front_default;
+            // add the retrieved url to the empty string
+            artUrl += officialArt;
+
             // pass art url on
             getPokeArt(artUrl);
 
             // grab species data url
-            var species = pokeData.species.url;
+            var species = urlData.species.url;
             // pass it on to get flavour text
-            getPokeFlavourText(species);
+            fetchPokeFlavourText(species);
         })
         .catch(function (error) {
             console.log(error);
@@ -217,13 +230,51 @@ function getPokeSpecies(pokemonUrl) {
 
 // to get the official artwork img url
 function getPokeArt(arturl) {
-    console.log(arturl);
+    // get the artwork url and push it to pokeArtwork array
+    pokeArtwork.push(arturl);
 }
 
 // to get the pokemon's pokedex entry (species flavour text)
-function getPokeFlavourText(species) {
-    console.log(species);
+function fetchPokeFlavourText(species) {
+    fetch(species)
+        .then(function (response) {
+            if (!response.ok) {
+                throw response.json();
+            } else {
+                return response.json();
+            }
+        })
+        .then(function (speciesData) {
+            console.log("species data");
+            console.log(speciesData);
+
+            // var flavourTexts = speciesData.flavor_text_entries;
+            // var allFlavourTexts = [];
+
+            
+
+            // getPokeEntry(allFlavourTexts);
+        })
+        .catch(function (error) {
+            console.log(error);
+        });
+
 }
+
+// function getPokeEntry(allflavourtexts) {
+//     console.log(allflavourtexts);
+
+//     let name = "silvally";
+
+//     switch (name) {
+//         case "kricketune":
+//             console.log(allflavourtexts[0].flavor_text);
+//             break;
+//         default:
+//             console.log(allflavourtexts)
+//     }
+
+// }
 
 
 getPokeApi();

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -112,28 +112,7 @@ function getArtistData(accessToken) {
 
 // POKEMON API functions
 
-// these variables may not end up being needed
-// var typesObj = {
-//     "bug": [],
-//     "dark": [],
-//     "dragon": [],
-//     "electric": [],
-//     "fairy": [],
-//     "fighting": [],
-//     "fire": [],
-//     "flying": [],
-//     "ghost": [],
-//     "grass": [],
-//     "ground": [],
-//     "ice": [],
-//     "normal": [],
-//     "poison": [],
-//     "psychic": [],
-//     "rock": [],
-//     "steel": [],
-//     "water": [],
-//     "random": []
-// }
+
 
 // arrays to store pokemon data separately
 var pokeName = [];  // for the pokemon name
@@ -141,11 +120,641 @@ var pokeType = [];  // for the pokemon typing
 var pokeArtwork = []; // for the pokemon's official artwork url
 var pokeEntry = []; // for the pokemon's flavour text
 
+var pokeId = [];
+
+
+var typeInfo = {
+    "bug": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "dark": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "dragon": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "electric": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "fairy": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "fighting": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "fire": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "flying": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "ghost": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "grass": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "ground": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "ice": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "normal": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "poison": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "psychic": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "rock": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "steel": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "water": { "name": {}, "id": {}, "artwork": {}, "entry": {} },
+    "random": { "name": {}, "id": {}, "artwork": {}, "entry": {} }
+}
+
+// var typeInfo = {
+//     "bug": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "dark": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "dragon": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "electric": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "fairy": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "fighting": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "fire": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "flying": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "ghost": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "grass": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "ground": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "ice": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "normal": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "poison": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "psychic": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "rock": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "steel": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "water": { "name": {}, "id": {}, "type": {}, "entry": {} },
+//     "random": { "name": {}, "id": {}, "type": {}, "entry": {} }
+// }
+
+// // these variables may not end up being needed
+// var typesObj = {
+//     "bug": [pokeName[0], pokeId[0], pokeType[0], pokeArtwork[0]],
+//     "dark": [pokeName[1], pokeId[1], pokeType[1], pokeArtwork[1]],
+//     "dragon": [pokeName[2], pokeId[2], pokeType[2], pokeArtwork[2]],
+//     "electric": [pokeName[3], pokeId[3], pokeType[3], pokeArtwork[3]],
+//     "fairy": [pokeName[4], pokeId[4], pokeType[4], pokeArtwork[4]],
+//     "fighting": [pokeName[5], pokeId[5], pokeType[5], pokeArtwork[5]],
+//     "fire": [pokeName[6], pokeId[6], pokeType[6], pokeArtwork[6]],
+//     "flying": [pokeName[7], pokeId[7], pokeType[7], pokeArtwork[7]],
+//     "ghost": [pokeName[8], pokeId[8], pokeType[8], pokeArtwork[8]],
+//     "grass": [pokeName[9], pokeId[9], pokeType[9], pokeArtwork[9]],
+//     "ground": [pokeName[10], pokeId[10], pokeType[10], pokeArtwork[10]],
+//     "ice": [pokeName[11], pokeId[11], pokeType[11], pokeArtwork[11]],
+//     "normal": [pokeName[12], pokeId[12], pokeType[12], pokeArtwork[12]],
+//     "poison": [pokeName[13], pokeId[13], pokeType[13], pokeArtwork[13]],
+//     "psychic": [pokeName[14], pokeId[14], pokeType[14], pokeArtwork[14]],
+//     "rock": [pokeName[15], pokeId[15], pokeType[15], pokeArtwork[15]],
+//     "steel": [pokeName[16], pokeId[16], pokeType[16], pokeArtwork[16]],
+//     "water": [pokeName[17], pokeId[17], pokeType[17], pokeArtwork[17]],
+//     "random": [pokeName[18], pokeId[18], pokeType[18], pokeArtwork[18]]
+// }
+
 // set up empty pokemon object to push name, type and data thru later
-var pokemonObj = {};
+// var pokemonObj = {};
 
 // CONNECT TO pokéAPI
 
+
+function getPokeApi() {
+    // add query 'limit=1126' to retrieve every pokémon (else it will retrieve 20 results at a time)
+    var pokemonApiUrl = "https://pokeapi.co/api/v2/pokemon/?limit=1126";
+
+    fetch(pokemonApiUrl)
+        .then(function (response) {
+            if (!response.ok) {
+                throw response.json();
+            } else {
+                return response.json();
+            }
+        })
+        .then(function (allPokemonData) {
+            let pokemon = allPokemonData.results;
+
+            // initial array to hold specific pokemon
+            let selectedPokemon = [
+                pokemon[401], // bug type: kricketune
+                pokemon[570], // dark type: zoroark
+                pokemon[380], // dragon type: latios
+                pokemon[178], // electric type: mareep
+                pokemon[699], // fairy type: sylveon
+                pokemon[891], // fighting type: urshifu
+                pokemon[725], // fire type: torracat
+                pokemon[16], // flying type: pidgeotto
+                pokemon[353], // ghost type: banette
+                pokemon[406], // grass type: roserade
+                pokemon[220], // ground type: piloswine
+                pokemon[711], // ice type: bergmite
+                pokemon[107], // normal type: lickitung
+                pokemon[434], // poison type: skuntank
+                pokemon[857], // psychic type: hatterene
+                pokemon[525], // rock type: gigalith
+                pokemon[305], // steel type: aggron
+                pokemon[729], // water type: primarina
+                pokemon[772], // random choice: silvally
+            ];
+
+            selectedPokemon.forEach(function (pokemon) {
+                getPokemonInfo(pokemon.url);
+            });
+        })
+        .catch(function (error) {
+            console.log(error);
+        });
+}
+
+function getPokemonInfo(url) {
+    // console.log(url);
+    fetch(url)
+        .then(function (response) {
+            if (!response.ok) {
+                throw response.json();
+            } else {
+                return response.json();
+            }
+        })
+        .then(function (data) {
+            // console.log(data);
+
+            var name = data.name;
+            getPokemonName(typeInfo, name);
+
+            var id = data.id;
+            getPokemonId(typeInfo, name, id);
+
+            // var type = data.types[0].type.name;
+            // getPokemonType(typeInfo, name, type);
+
+            var artwork = "";
+            var artLocation = data.sprites.other["official-artwork"].front_default;
+            artwork += artLocation;
+            getPokemonArt(typeInfo, name, artwork);
+
+            var species = data.species.url;
+            getPokemonSpecies(typeInfo, name, species);
+
+            console.log("get pokemon info: ");
+            console.log(typeInfo);
+
+        })
+        .catch(function (error) {
+            console.log(error);
+        });
+}
+
+function getPokemonName(typeobj, name) {
+    let pokemon = name;
+
+    switch (pokemon) {
+        case "kricketune":
+            typeobj.bug.name = name;
+            // console.log(typeobj);
+            break;
+        case "zoroark":
+            typeobj.dark.name = name;
+            // console.log(typeobj);
+            break;
+        case "latios":
+            typeobj.dragon.name = name;
+            // console.log(typeobj);
+            break;
+        case "mareep":
+            typeobj.electric.name = name;
+            // console.log(typeobj);
+            break;
+        case "sylveon":
+            typeobj.fairy.name = name;
+            // console.log(typeobj);
+            break;
+
+        case "urshifu-single-strike":
+            let urshifu = name.split("-")[0];
+            typeobj.fighting.name = urshifu;
+            // console.log(typeobj);
+            break;
+        case "torracat":
+            typeobj.fire.name = name;
+            // console.log(typeobj);
+            break;
+        case "pidgeotto":
+            typeobj.flying.name = name;
+            // console.log(typeobj);
+            break;
+        case "banette":
+            typeobj.ghost.name = name;
+            // console.log(typeobj);
+            break;
+        case "roserade":
+            typeobj.grass.name = name;
+            // console.log(typeobj);
+            break;
+
+        case "piloswine":
+            typeobj.ground.name = name;
+            // console.log(typeobj);
+            break;
+        case "bergmite":
+            typeobj.ice.name = name;
+            // console.log(typeobj);
+            break;
+        case "lickitung":
+            typeobj.normal.name = name;
+            // console.log(typeobj);
+            break;
+        case "skuntank":
+            typeobj.poison.name = name;
+            // console.log(typeobj);
+            break;
+        case "hatterene":
+            typeobj.psychic.name = name;
+            // console.log(typeobj);
+            break;
+
+        case "gigalith":
+            typeobj.rock.name = name;
+            // console.log(typeobj);
+            break;
+        case "aggron":
+            typeobj.steel.name = name;
+            // console.log(typeobj);
+            break;
+        case "primarina":
+            typeobj.water.name = name;
+            // console.log(typeobj);
+            break;
+        case "silvally":
+            typeobj.random.name = name;
+            // console.log(typeobj);
+            break;
+        default: 
+            console.log("default break: nothing");
+            break;
+    }
+}
+
+function getPokemonId(typeobj, name, id) {
+    let pokemon = name;
+
+    switch (pokemon) {
+        case "kricketune":
+            typeobj.bug.id = id;
+            // console.log(typeobj);
+            break;
+        case "zoroark":
+            typeobj.dark.id = id;
+            // console.log(typeobj);
+            break;
+        case "latios":
+            typeobj.dragon.id = id;
+            // console.log(typeobj);
+            break;
+        case "mareep":
+            typeobj.electric.id = id;
+            // console.log(typeobj);
+            break;
+        case "sylveon":
+            typeobj.fairy.id = id;
+            // console.log(typeobj);
+            break;
+
+        case "urshifu-single-strike":
+            typeobj.fighting.id = id;
+            // console.log(typeobj);
+            break;
+        case "torracat":
+            typeobj.fire.id = id;
+            // console.log(typeobj);
+            break;
+        case "pidgeotto":
+            typeobj.flying.id = id;
+            // console.log(typeobj);
+            break;
+        case "banette":
+            typeobj.ghost.id = id;
+            // console.log(typeobj);
+            break;
+        case "roserade":
+            typeobj.grass.id = id;
+            // console.log(typeobj);
+            break;
+
+        case "piloswine":
+            typeobj.ground.id = id;
+            // console.log(typeobj);
+            break;
+        case "bergmite":
+            typeobj.ice.id = id;
+            // console.log(typeobj);
+            break;
+        case "lickitung":
+            typeobj.normal.id = id;
+            // console.log(typeobj);
+            break;
+        case "skuntank":
+            typeobj.poison.id = id;
+            // console.log(typeobj);
+            break;
+        case "hatterene":
+            typeobj.psychic.id = id;
+            // console.log(typeobj);
+            break;
+
+        case "gigalith":
+            typeobj.rock.id = id;
+            // console.log(typeobj);
+            break;
+        case "aggron":
+            typeobj.steel.id = id;
+            // console.log(typeobj);
+            break;
+        case "primarina":
+            typeobj.water.id = id;
+            // console.log(typeobj);
+            break;
+        case "silvally": 
+            typeobj.random.id = id;
+            // console.log(typeobj);
+            break;
+        default:
+            console.log("default break: nothing");
+            break;
+    }
+}
+
+// function getPokemonType here (don't actually need it)
+/*
+function getPokemonType(typeobj, name, type) {
+    let pokemon = name;
+
+    switch (pokemon) {
+        case "kricketune":
+            typeobj.bug.type = type;
+            console.log(typeobj);
+            break;
+        case "zoroark":
+            typeobj.dark.type = type;
+            console.log(typeobj);
+            break;
+        case "latios":
+            typeobj.dragon.type = type;
+            console.log(typeobj);
+            break;
+        case "mareep":
+            typeobj.electric.type = type;
+            console.log(typeobj);
+            break;
+        case "sylveon":
+            typeobj.fairy.type = type;
+            console.log(typeobj);
+            break;
+
+        case "urshifu-single-strike":
+            typeobj.fighting.type = type;
+            console.log(typeobj);
+            break;
+        case "torracat":
+            typeobj.fire.type = type;
+            console.log(typeobj);
+            break;
+        case "ptypegeotto":
+            typeobj.flying.type = type;
+            console.log(typeobj);
+            break;
+        case "banette":
+            typeobj.ghost.type = type;
+            console.log(typeobj);
+            break;
+        case "roserade":
+            typeobj.grass.type = type;
+            console.log(typeobj);
+            break;
+
+        case "piloswine":
+            typeobj.ground.type = type;
+            console.log(typeobj);
+            break;
+        case "bergmite":
+            typeobj.ice.type = type;
+            console.log(typeobj);
+            break;
+        case "lickitung":
+            typeobj.normal.type = type;
+            console.log(typeobj);
+            break;
+        case "skuntank":
+            typeobj.poison.type = type;
+            console.log(typeobj);
+            break;
+        case "hatterene":
+            typeobj.psychic.type = type;
+            console.log(typeobj);
+            break;
+
+        case "gigalith":
+            typeobj.rock.type = type;
+            console.log(typeobj);
+            break;
+        case "aggron":
+            typeobj.steel.type = type;
+            console.log(typeobj);
+            break;
+        case "primarina":
+            typeobj.water.type = type;
+            console.log(typeobj);
+            break;
+        case "silvally": 
+            typeobj.random.type = type;
+            console.log(typeobj);
+            break;
+        default:
+            console.log("default break: nothing");
+            break;
+    }
+}
+*/
+
+function getPokemonArt(typeobj, name, artwork) {
+    let pokemon = name;
+
+    switch (pokemon) {
+        case "kricketune":
+            typeobj.bug.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "zoroark":
+            typeobj.dark.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "latios":
+            typeobj.dragon.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "mareep":
+            typeobj.electric.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "sylveon":
+            typeobj.fairy.artwork = artwork;
+            // console.log(typeobj);
+            break;
+
+        case "urshifu-single-strike":
+            typeobj.fighting.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "torracat":
+            typeobj.fire.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "partworkgeotto":
+            typeobj.flying.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "banette":
+            typeobj.ghost.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "roserade":
+            typeobj.grass.artwork = artwork;
+            // console.log(typeobj);
+            break;
+
+        case "piloswine":
+            typeobj.ground.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "bergmite":
+            typeobj.ice.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "lickitung":
+            typeobj.normal.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "skuntank":
+            typeobj.poison.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "hatterene":
+            typeobj.psychic.artwork = artwork;
+            // console.log(typeobj);
+            break;
+
+        case "gigalith":
+            typeobj.rock.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "aggron":
+            typeobj.steel.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "primarina":
+            typeobj.water.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        case "silvally": 
+            typeobj.random.artwork = artwork;
+            // console.log(typeobj);
+            break;
+        default:
+            console.log("default break: nothing");
+            break;
+    }
+}
+
+function getPokemonSpecies(typeobj, name, species) {
+    // console.log(url);
+    fetch(species)
+        .then(function (response) {
+            if (!response.ok) {
+                throw response.json();
+            } else {
+                return response.json();
+            }
+        })
+        .then(function (speciesdata) {
+            // console.log(speciesdata);
+            getEntry(typeobj, name, speciesdata);
+        })
+        .catch(function (error) {
+            console.log(error);
+        });
+}
+
+function getEntry(typeobj, name, speciesdata) {
+    let entry = speciesdata.flavor_text_entries;
+    let pokemon = name;
+
+    switch (pokemon) {
+        case "kricketune":
+            typeobj.bug.entry = entry[3].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "zoroark":
+            typeobj.dark.entry = entry[3].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "latios":
+            typeobj.dragon.entry = entry[2].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "mareep":
+            typeobj.electric.entry = entry[5].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "sylveon":
+            typeobj.fairy.entry = entry[6].flavor_text;
+            // console.log(typeobj);
+            break;
+
+        case "urshifu-single-strike":
+            typeobj.fighting.entry = entry[7].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "torracat":
+            typeobj.fire.entry = entry[58].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "pentrygeotto":
+            typeobj.flying.entry = entry[14].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "banette":
+            typeobj.ghost.entry = entry[3].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "roserade":
+            typeobj.grass.entry = entry[1].flavor_text;
+            // console.log(typeobj);
+            break;
+
+        case "piloswine":
+            typeobj.ground.entry = entry[6].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "bergmite":
+            typeobj.ice.entry = entry[39].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "lickitung":
+            typeobj.normal.entry = entry[9].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "skuntank":
+            typeobj.poison.entry = entry[0].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "hatterene":
+            typeobj.psychic.entry = entry[7].flavor_text;
+            // console.log(typeobj);
+            break;
+
+        case "gigalith":
+            typeobj.rock.entry = entry[1].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "aggron":
+            typeobj.steel.entry = entry[2].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "primarina":
+            typeobj.water.entry = entry[37].flavor_text;
+            // console.log(typeobj);
+            break;
+        case "silvally": 
+            typeobj.random.entry = entry[7].flavor_text;
+            // console.log(typeobj);
+            break;
+        default:
+            console.log("default break: nothing");
+            break;
+    }
+}
+
+getPokeApi();
+
+
+/* 
 // first call to pokéAPI: fetch data for all pokémon
 function getPokeApi() {
     // add query 'limit=1126' to retrieve every pokémon (else it will retrieve 20 results at a time)
@@ -274,6 +883,7 @@ function fetchPokeSpecies(pokemonUrl) {
 function getPokeArt(arturl) {
     // get the artwork url and push it to pokeArtwork array
     pokeArtwork.push(arturl);
+    console.log(arturl);
 }
 
 // to get the pokemon's pokedex entry (species flavour text)
@@ -296,119 +906,48 @@ function fetchPokeFlavourText(species) {
 
 }
 
-/* IMPORTANT NOTE: because there are a lot of different flavour text entries available for each pokemon (and a number of them are in languages other than English), and because not all entries assigned to the first index of flavour_text_entries are in English, it's important to be able to select the specific flavour text we want */
+// IMPORTANT NOTE: because there are a lot of different flavour text entries available for each pokemon (and a number of them are in languages other than English), and because not all entries assigned to the first index of flavour_text_entries are in English, it's important to be able to select the specific flavour text we want
 
 // pick the specific flavour text to use for each pokemon
 function assignPokeEntry(speciesdata) {
     // target the name of pokemon to enable switch case usage
     let name = speciesdata.name;
-    // console.log(speciesdata);
-    console.log(name);
+    // let unorderedPokeEntry = [];
+    // let index = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
 
-    switch (name) {
-        case "kricketune":
-            // console.log(speciesdata.flavor_text_entries[3].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[3].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "zoroark":
-            // console.log(speciesdata.flavor_text_entries[3].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[3].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "latios":
-            // console.log(speciesdata.flavor_text_entries[2].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[2].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "mareep":
-            // console.log(speciesdata.flavor_text_entries[5].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[5].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "sylveon":
-            // console.log(speciesdata.flavor_text_entries[6].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[6].flavor_text);
-            console.log(pokeEntry);
-            break;
+    
+    //     if (name.includes("kricketune")) {
+    //         unorderedPokeEntry[1].push("kricketune " + speciesdata.flavor_text_entries[3].flavor_text);
+    //     }
 
-        case "urshifu":
-            // console.log(speciesdata.flavor_text_entries[7].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[7].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "torracat":
-            // console.log(speciesdata.flavor_text_entries[58].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[58].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "pidgeotto":
-            // console.log(speciesdata.flavor_text_entries[14].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[14].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "banette":
-            // console.log(speciesdata.flavor_text_entries[3].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[3].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "roserade":
-            // console.log(speciesdata.flavor_text_entries[1].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[1].flavor_text);
-            console.log(pokeEntry);
-            break;
+    //     if (name.includes("zoroark")) {
+    //         unorderedPokeEntry[2].push(speciesdata.flavor_text_entries[3].flavor_text);
+    //     }
 
-        case "piloswine":
-            // console.log(speciesdata.flavor_text_entries[6].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[6].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "bergmite":
-            // console.log(speciesdata.flavor_text_entries[39].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[39].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "lickitung":
-            // console.log(speciesdata.flavor_text_entries[9].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[9].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "skuntank":
-            // console.log(speciesdata.flavor_text_entries[0].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[0].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "hatterene":
-            // console.log(speciesdata.flavor_text_entries[7].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[7].flavor_text);
-            console.log(pokeEntry);
-            break;
+    //     if (name.includes("latios")) {
+    //         unorderedPokeEntry[3].push(speciesdata.flavor_text_entries[2].flavor_text);
+    //     }
 
-        case "gigalith":
-            // console.log(speciesdata.flavor_text_entries[1].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[1].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "aggron":
-            // console.log(speciesdata.flavor_text_entries[2].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[2].flavor_text);
-            console.log(pokeEntry);
-            break;
-        case "primarina":
-            // console.log(speciesdata.flavor_text_entries[37].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[37].flavor_text);
-            console.log(pokeEntry);
-            break;
+    //     if (name.includes("mareep")) {
+    //         unorderedPokeEntry[4].push(speciesdata.flavor_text_entries[5].flavor_text);
+    //     }
 
-        default:
-            // console.log(speciesdata.flavor_text_entries[7].flavor_text);
-            pokeEntry.push(speciesdata.flavor_text_entries[7].flavor_text);
-            console.log(pokeEntry);
-            break;
-    }
+    //     if (name.includes("sylveon")) {
+    //         unorderedPokeEntry[5].push(speciesdata.flavor_text_entries[6].flavor_text);
+    //     }
+
+    //     if (name.includes("urshifu")) {
+    //         unorderedPokeEntry[6].push(speciesdata.flavor_text_entries[7].flavor_text);
+    //     }
+
+    //     console.log(unorderedPokeEntry);
+    //     return unorderedPokeEntry;
+    // }
 }
 
 getPokeApi();
+
+*/
 
 //THIS EVENT LISTENER WILL NEED TO CHANGE TO THE FORM SUBMIT BUTTON WHEN WE CREATE THE USER INPUT FIELD
 artistBtn.addEventListener("click", getSpotifyToken)

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -306,67 +306,105 @@ function assignPokeEntry(speciesdata) {
     console.log(name);
 
     switch (name) {
-        // cases 1-5
         case "kricketune":
-            console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[3].flavor_text);
+            console.log(pokeEntry);
             break;
         case "zoroark":
-            console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[3].flavor_text);
+            console.log(pokeEntry);
             break;
         case "latios":
-            console.log(speciesdata.flavor_text_entries[2].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[2].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[2].flavor_text);
+            console.log(pokeEntry);
             break;
         case "mareep":
-            console.log(speciesdata.flavor_text_entries[5].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[5].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[5].flavor_text);
+            console.log(pokeEntry);
             break;
         case "sylveon":
-            console.log(speciesdata.flavor_text_entries[6].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[6].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[6].flavor_text);
+            console.log(pokeEntry);
             break;
-        // cases 6-10
+
         case "urshifu":
-            console.log(speciesdata.flavor_text_entries[7].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[7].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[7].flavor_text);
+            console.log(pokeEntry);
             break;
         case "torracat":
-            console.log(speciesdata.flavor_text_entries[58].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[58].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[58].flavor_text);
+            console.log(pokeEntry);
             break;
         case "pidgeotto":
-            console.log(speciesdata.flavor_text_entries[14].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[14].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[14].flavor_text);
+            console.log(pokeEntry);
             break;
         case "banette":
-            console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[3].flavor_text);
+            console.log(pokeEntry);
             break;
         case "roserade":
-            console.log(speciesdata.flavor_text_entries[1].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[1].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[1].flavor_text);
+            console.log(pokeEntry);
             break;
-        // cases 11-15
+
         case "piloswine":
-            console.log(speciesdata.flavor_text_entries[6].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[6].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[6].flavor_text);
+            console.log(pokeEntry);
             break;
         case "bergmite":
-            console.log(speciesdata.flavor_text_entries[39].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[39].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[39].flavor_text);
+            console.log(pokeEntry);
             break;
         case "lickitung":
-            console.log(speciesdata.flavor_text_entries[9].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[9].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[9].flavor_text);
+            console.log(pokeEntry);
             break;
         case "skuntank":
-            console.log(speciesdata.flavor_text_entries[0].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[0].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[0].flavor_text);
+            console.log(pokeEntry);
             break;
         case "hatterene":
-            console.log(speciesdata.flavor_text_entries[7].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[7].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[7].flavor_text);
+            console.log(pokeEntry);
             break;
-        // cases 16-18
+
         case "gigalith":
-            console.log(speciesdata.flavor_text_entries[1].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[1].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[1].flavor_text);
+            console.log(pokeEntry);
             break;
         case "aggron":
-            console.log(speciesdata.flavor_text_entries[2].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[2].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[2].flavor_text);
+            console.log(pokeEntry);
             break;
         case "primarina":
-            console.log(speciesdata.flavor_text_entries[37].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[37].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[37].flavor_text);
+            console.log(pokeEntry);
             break;
-        // case 19 (the 'random' type as default)
+
         default:
-            console.log(speciesdata.flavor_text_entries[7].flavor_text);
+            // console.log(speciesdata.flavor_text_entries[7].flavor_text);
+            pokeEntry.push(speciesdata.flavor_text_entries[7].flavor_text);
+            console.log(pokeEntry);
+            break;
     }
 }
 

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -139,7 +139,6 @@ function getArtistData(accessToken) {
 var pokeName = [];  // for the pokemon name
 var pokeType = [];  // for the pokemon typing
 var pokeArtwork = []; // for the pokemon's official artwork url
-var speciesArray = []; // to store pokemon species data
 var pokeEntry = []; // for the pokemon's flavour text
 
 // set up empty pokemon object to push name, type and data thru later
@@ -149,7 +148,6 @@ var pokemonObj = {};
 
 // first call to pokéAPI: fetch data for all pokémon
 function getPokeApi() {
-
     // add query 'limit=1126' to retrieve every pokémon (else it will retrieve 20 results at a time)
     var pokemonApiUrl = "https://pokeapi.co/api/v2/pokemon/?limit=1126";
 
@@ -289,8 +287,8 @@ function fetchPokeFlavourText(species) {
             }
         })
         .then(function (speciesData) {
-            // push each species data into the species data array
-            speciesArray.push(speciesData);
+            // pass on all species data to next function
+            assignPokeEntry(speciesData);
         })
         .catch(function (error) {
             console.log(error);
@@ -298,15 +296,81 @@ function fetchPokeFlavourText(species) {
 
 }
 
+/* IMPORTANT NOTE: because there are a lot of different flavour text entries available for each pokemon (and a number of them are in languages other than English), and because not all entries assigned to the first index of flavour_text_entries are in English, it's important to be able to select the specific flavour text we want */
+
+// pick the specific flavour text to use for each pokemon
+function assignPokeEntry(speciesdata) {
+    // target the name of pokemon to enable switch case usage
+    let name = speciesdata.name;
+    // console.log(speciesdata);
+    console.log(name);
+
+    switch (name) {
+        // cases 1-5
+        case "kricketune":
+            console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            break;
+        case "zoroark":
+            console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            break;
+        case "latios":
+            console.log(speciesdata.flavor_text_entries[2].flavor_text);
+            break;
+        case "mareep":
+            console.log(speciesdata.flavor_text_entries[5].flavor_text);
+            break;
+        case "sylveon":
+            console.log(speciesdata.flavor_text_entries[6].flavor_text);
+            break;
+        // cases 6-10
+        case "urshifu":
+            console.log(speciesdata.flavor_text_entries[7].flavor_text);
+            break;
+        case "torracat":
+            console.log(speciesdata.flavor_text_entries[58].flavor_text);
+            break;
+        case "pidgeotto":
+            console.log(speciesdata.flavor_text_entries[14].flavor_text);
+            break;
+        case "banette":
+            console.log(speciesdata.flavor_text_entries[3].flavor_text);
+            break;
+        case "roserade":
+            console.log(speciesdata.flavor_text_entries[1].flavor_text);
+            break;
+        // cases 11-15
+        case "piloswine":
+            console.log(speciesdata.flavor_text_entries[6].flavor_text);
+            break;
+        case "bergmite":
+            console.log(speciesdata.flavor_text_entries[39].flavor_text);
+            break;
+        case "lickitung":
+            console.log(speciesdata.flavor_text_entries[9].flavor_text);
+            break;
+        case "skuntank":
+            console.log(speciesdata.flavor_text_entries[0].flavor_text);
+            break;
+        case "hatterene":
+            console.log(speciesdata.flavor_text_entries[7].flavor_text);
+            break;
+        // cases 16-18
+        case "gigalith":
+            console.log(speciesdata.flavor_text_entries[1].flavor_text);
+            break;
+        case "aggron":
+            console.log(speciesdata.flavor_text_entries[2].flavor_text);
+            break;
+        case "primarina":
+            console.log(speciesdata.flavor_text_entries[37].flavor_text);
+            break;
+        // case 19 (the 'random' type as default)
+        default:
+            console.log(speciesdata.flavor_text_entries[7].flavor_text);
+    }
+}
 
 getPokeApi();
-
-// testing
-console.log("pokemon name:");
-console.log(pokeName);
-
-console.log("species data: ");
-console.log(speciesArray);
 
 //THIS EVENT LISTENER WILL NEED TO CHANGE TO THE FORM SUBMIT BUTTON WHEN WE CREATE THE USER INPUT FIELD
 artistBtn.addEventListener("click", getSpotifyToken)

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -139,7 +139,8 @@ function getArtistData(accessToken) {
 var pokeName = [];  // for the pokemon name
 var pokeType = [];  // for the pokemon typing
 var pokeArtwork = []; // for the pokemon's official artwork url
-var pokeEntry = []; // for the pokemon's species description
+var speciesArray = []; // to store pokemon species data
+var pokeEntry = []; // for the pokemon's flavour text
 
 // set up empty pokemon object to push name, type and data thru later
 var pokemonObj = {};
@@ -261,7 +262,7 @@ function fetchPokeSpecies(pokemonUrl) {
             // pass art url on
             getPokeArt(artUrl);
 
-            // grab species data url
+            // grab each species' data url
             var species = urlData.species.url;
             // pass it on to get flavour text
             fetchPokeFlavourText(species);
@@ -288,15 +289,8 @@ function fetchPokeFlavourText(species) {
             }
         })
         .then(function (speciesData) {
-            console.log("species data");
-            console.log(speciesData);
-
-            var flavourTexts = speciesData.flavor_text_entries;
-            var allFlavourTexts = [];
-
-            
-
-            // getPokeEntry(allFlavourTexts);
+            // push each species data into the species data array
+            speciesArray.push(speciesData);
         })
         .catch(function (error) {
             console.log(error);
@@ -304,23 +298,15 @@ function fetchPokeFlavourText(species) {
 
 }
 
-// function getPokeEntry(allflavourtexts) {
-//     console.log(allflavourtexts);
-
-//     let name = "silvally";
-
-//     switch (name) {
-//         case "kricketune":
-//             console.log(allflavourtexts[0].flavor_text);
-//             break;
-//         default:
-//             console.log(allflavourtexts)
-//     }
-
-// }
-
 
 getPokeApi();
+
+// testing
+console.log("pokemon name:");
+console.log(pokeName);
+
+console.log("species data: ");
+console.log(speciesArray);
 
 //THIS EVENT LISTENER WILL NEED TO CHANGE TO THE FORM SUBMIT BUTTON WHEN WE CREATE THE USER INPUT FIELD
 artistBtn.addEventListener("click", getSpotifyToken)


### PR DESCRIPTION
This pull requests addresses the following issues: #4, #32, #33, #50, #51

**Issue reference #50: Clean up Pokémon data retrieval code**
I went over my previous code and refactored it to look cleaner and use fewer lines. Previously the data retrieval was split into multiple functions with some functions nested deep in others, which made the function tree messy because it wasn't as clear which functions branched into what.

I removed the separate global arrays for Pokémon name, type, artwork. In their place, I created a single global object called _typeInfo_, which you can think of as a complete typing info list. For each of the 19 types (18 official + 1 for random), their key holds information on that specific typing's chosen Pokémon: the Pokémon's name, their ID, their artwork url, and their flavour text.

The great thing is that this object gets fully populated with information as early as the second pokéAPI fetch call!

Pokémon name, ID, and artwork url gets retrieved in a single function called _fillPokemonDetails_, which uses a switch case statement based off the Pokémon's name. 

**Issue reference #4: Retrieve Pokémon data (image)**
The code successfully pulls down the img url from pokéAPI and adds it to the _typeInfo_ object. You can find the artwork grab in the function _fillPokemonDetails_. It looks like this:
```
    switch (pokemon) {
        case "kricketune":
            typeobj.bug.artwork = artwork;
            break;
```

**Issue reference #33: Retrieve Pokémon data (species)**
This code successfully fetches the pokemon_species url for each of the chosen Pokémon and passes that data onto the next function, which is for specific flavour text retrieval.

**Issue reference: #32 Retrieve Pokémon data (entry)**
The first thing to note is that each Pokémon can have multiple entries for their species description, because each new game gives the Pokémon (if it appears in that game) its own flavour text. In the later games, these descriptions can be in languages other than English. That is why we need to manually choose which flavour text entry to add to the _typeInfo_ object.

Pokémon description retrieval is done in two steps: first the Pokémon species url is grabbed out of pokéAPI (#33), and then a switch case statement is used (again based off the Pokémon's name) to select the specific flavour text to be added to _typeInfo_.
```    
switch (pokemon) {
        case "kricketune":
            typeobj.bug.entry = entry[3].flavor_text;
            break;
        case "piloswine":
            typeobj.ground.entry = entry[6].flavor_text;
            break;
```

**Issue reference #51: Split Urshifu's name**
A minor tweak to Urshifu's name data. From pokéAPI it gets retrieved as "urshifu-single-strike". To make it read only "urshifu" in _typeInfo_ fighting type name, "urshifu-single-strike" is split using "-" as dividers, and the first index of the new array returned [0] is the one that gets added to _typeInfo_.
```
        case "urshifu-single-strike":
            let urshifu = name.split("-")[0];
            typeobj.fighting.name = urshifu;
            break;
```